### PR TITLE
Updates to Lesson 1 Introduction to SageMath notebook

### DIFF
--- a/Lesson1-Introduction.ipynb
+++ b/Lesson1-Introduction.ipynb
@@ -5,78 +5,77 @@
    "metadata": {},
    "source": [
     "# Lesson 1 - Introduction to Python and SageMath\n",
-    "time: 30 - 45 minutes\n",
+    "Expected completion time: 30 - 45 minutes\n",
     "\n",
     "In this lesson we will introduce some of the fundamental concepts in Python and SageMath. \n",
-    "This will then be used in subsequent lessons. \n",
+    "These will then be used in subsequent lessons. \n",
     "\n",
-    "## Learning outcomes: \n",
-    "1. Know what SageMath is and how to start i\n",
-    "1. Learn how to run Sage\n",
-    "2. Start a notebook\n",
-    "3. Basic expressions and variables \n",
-    "- variable types, dicts, lists \n",
-    "- functions, passing arguments by value or reference \n",
-    "- loops v/s list comprehensions\n",
-    "- exceptions\n",
-    "- docstrings\n",
+    "## Learning outcomes\n",
     "\n",
-    "## What is SageMath\n",
+    "1. Introduction to SageMath\n",
+    "2. Learn how to run Sage\n",
+    "3. Start a notebook\n",
+    "4. Basic expressions and variables \n",
+    "  - variable types, dicts, lists \n",
+    "  - functions, passing arguments by value or reference \n",
+    "  - loops vs. list comprehensions\n",
+    "  - exceptions\n",
+    "  - docstrings\n",
+    "\n",
+    "## What is SageMath?\n",
     "\n",
     "SageMath (formerly known as just SAGE (System for Algebra and Geometry Experimentation), but renamed to avoid confusion with another well-known software...) was originally developed by William Stein and first released in 2005. \n",
-    "The intention behind SageMath was/is to provide a free, open source, alternative to Magma, Maple, Mathematica, MATLAB etc. with an easy to use interface (both to use and to develop in) built on Python (Cython) and which can integrate with other free or commercial packages (which then needs to be installed separately).\n",
-    "- Default installation contains many (at least 84) different free packages, including e.g.:\n",
-    "  - Pari/GP\n",
-    "  - GAP\n",
-    "  - singular\n",
-    "  - R\n",
-    "  - numpy\n",
-    "  - matplotlib\n",
-    "  - ...\n",
-    "  For full list see: https://www.sagemath.org/links-components.html\n",
-    "- it can be integrated with existing commercial packages like\n",
-    "  - Magma\n",
-    "  - Mathematica\n",
-    "  - Maple\n",
+    "The intention behind SageMath is to provide a free, open source, alternative to Magma, Maple, Mathematica, MATLAB etc. with an easy to use interface (both for end-users and developers) built on Python (Cython) and which can integrate with other free or commercial packages (which are installed separately).\n",
     "\n",
-    "Full documentation is included in the source of SageMath and is available online, together with a multitude of tutorials etc. See for instance https://www.sagemath.org/tour.html\n",
+    "The default [installation](https://wiki.sagemath.org/DownloadAndInstallationGuide) contains many (at least 84) different free packages, including:\n",
+    "- Pari/GP\n",
+    "- GAP\n",
+    "- singular\n",
+    "- R\n",
+    "- numpy\n",
+    "- matplotlib\n",
+    "- ...\n",
+    "- For full list see: https://www.sagemath.org/links-components.html\n",
+    "\n",
+    "It can be integrated with existing commercial packages like\n",
+    "- Magma\n",
+    "- Mathematica\n",
+    "- Maple\n",
+    "\n",
+    "Full documentation is included in the source of SageMath and is available online, together with a multitude of tutorials etc.<br> See for instance https://www.sagemath.org/tour.html\n",
     "\n",
     "## Optional packages\n",
-    "There are some packages that are not shipped with SageMath but are available to install \n",
+    "There are some packages that are not shipped with SageMath but are available to install afterwards\n",
+    "- In the SageMath console\n",
+    "  - `sage -i <package_name>` - to install optional sage packages\n",
+    "  - `sage -pip install <py_package_name>` - to install optional python packages using `pip`\n",
+    "- In the SageMath Shell:\n",
+    "  - `sage: installed_packages()` - gives a list of all installed packages\n",
+    "  - `sage: optional_packages()` gives a list of instaled and available optional packages\n",
     "\n",
-    "` sage -i <package_name>`  - optional sage packages\n",
-    "\n",
-    "` sage -pip install <py_package_name>` - optional python packages\n",
-    "\n",
-    "or in the sage shell:\n",
-    "\n",
-    "`sage: installed_packages()` - gives a list of all installed packages\n",
-    "\n",
-    "`sage: optional_packages()` gives a list of instaled and available optional packages\n",
-    "\n",
-    "For example. To install additional GAP packages: \n",
-    "\n",
-    "`sage -i gap_packages`\n",
-    "\n",
+    "For example, use the SageMath console to install additional GAP packages by writing `sage -i gap_packages`\n",
     "\n",
     "## How to start SageMath\n",
     "\n",
-    "- Command line (interactive)\n",
+    "- **On your own machine** (with SageMath installed)\n",
+    "  - From the command line (interactive)\n",
+    "    - `$ sage`\n",
+    "    - Use `sage --help` to see all options, e.g. `--python`, `--pip`, etc.\n",
+    "  - From a (Jupyter) Notebook interface:\n",
+    "    - `$sage --notebook=jupyter --notebook-dir=<dir>`\n",
+    "- **Online**\n",
+    "  - SageMathCell: https://sagecell.sagemath.org/ - write SageMath code directly in the browser\n",
+    "  - Cocalc: https://cocalc.com - full interactive notebook environment (compare with Google Colab)\n",
     "\n",
-    "    `$ sage `\n",
-    "    Do `sage --help` to see all options, e.g. `--python`, `--pip`, etc.\n",
-    "\n",
-    "- Notebook (jupyter) interface:\n",
-    "    \n",
-    "    `$sage --notebook=jupyter --notebook-dir=<dir>`\n",
-    "- Cocalc: https://cocalc.com\n",
-    "- Sage Cell: https://sagecell.sagemath.org/\n",
-    "    \n",
-    "    \n",
-    "## Useful to know when using SageMath:\n",
+    "## Getting help with SageMath:\n",
     "- `<function_name>?` to read documentation (docstring)\n",
     "- `<function_name>??` to read the source (if available)\n",
-    "- `<object_name>.<tab>` - use tab completion to see available properties."
+    "- `<object_name>.<tab>` - use tab completion to see available properties.\n",
+    "- Help button in the toolbar links to the [online documentation](https://doc.sagemath.org/html/en/reference/index.html)\n",
+    "\n",
+    "**Example**: Try using these features for yourself below. Run a code cell by first selecting it and then either\n",
+    "- Press the `Run` button in the toolbar above\n",
+    "- Use the keyboard shortcut `Ctrl+Enter` or `Shift+Enter`"
    ]
   },
   {
@@ -103,6 +102,11 @@
    "metadata": {},
    "source": [
     "## Programming in SageMath\n",
+    "\n",
+    "Check that your kernel is set to SageMath (e.g. SageMath 9.0) in the top right of the toolbar. <br>\n",
+    "You can change your kernel using the `Kernel` button on the toolbar to set the default to Python (2.7 or 3.x depending on your version of SageMath). <br>\n",
+    "Since version 9.0 released in January 2020, SageMath is using Python 3.\n",
+    "\n",
     "Since the main functionality of SageMath is written in Python it means that most of the programming can be done using Python. There are however some subtle differences.\n",
     "\n",
     "### Variable types in Python\n",
@@ -112,7 +116,8 @@
     "- Tuple: `tuple`\n",
     "- Dictionary: `dict`\n",
     "- Set: `set`\n",
-    "\n"
+    "\n",
+    "**Example**: Run the cell below to explore basic data types in Python"
    ]
   },
   {
@@ -121,19 +126,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# We run Jupyter cells in SageMath mode by default but can run individual cells in Python2 or 3 \n",
-    "# (unfortunately Python2 is still the default so better be explicit). \n",
     "%%python3\n",
-    "x=2\n",
-    "print(x,type(x))\n",
-    "y=2.0; print(y,type(y))  #Combine multiple statements with ';' -- avoid this in practice since it reduces readability \n",
-    "r = 3/4; print(r,type(r))\n",
-    "z= 1+1j; print(z,type(z))\n",
-    "s=\"hello\"; print(s,type(s))\n",
-    "l = [1,2,3]; print(l,type(l))\n",
-    "t = (1,2,3); print(t,type(t))\n",
-    "d = {1:'a','b':2}; print(d,type(d))\n",
-    "A = set([1,2,3,4]); print(A,type(A))"
+    "# We run Jupyter cells in SageMath mode by default but can run individual cells in Python using Jupyter magics\n",
+    "# As Python 2 is still the default for older versions of SageMath it is better to be explicit about Python version. \n",
+    "\n",
+    "x = 2\n",
+    "print(x, type(x)) # int\n",
+    "\n",
+    "# Combine multiple statements with ';' -- avoid this in practice since it reduces readability \n",
+    "y = 2.0; print(y, type(y)) # float\n",
+    "r = 3/4; print(r, type(r)) # float\n",
+    "z = 1+1j; print(z, type(z)) # complex\n",
+    "s = \"hello\"; print(s, type(s)) # string\n",
+    "l = [1,2,3]; print(l, type(l)) # list\n",
+    "t = (1,2,3); print(t, type(t)) # tuple\n",
+    "d = {1:'a','b':2}; print(d, type(d)) # dictionary\n",
+    "A = set([1,2,3,4]); print(A, type(A)) # set"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that in Python 2, dividing two `int` variables uses \"integer division with floor floor function\""
    ]
   },
   {
@@ -143,9 +158,19 @@
    "outputs": [],
    "source": [
     "%%python2\n",
-    "# Note in Python2 integer division is uses \"integer division\" (w/ floor)\n",
     "r = 3/4; print(r,type(r))\n",
     "r =-3/4; print(r,type(r))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Variable types in SageMath\n",
+    "\n",
+    "In SageMath defaults for many numeric types are overwritten. For example:\n",
+    "- Integers are by default cast to SageMath's `Integer` type, which has different behaviour from Python's `int`\n",
+    "- Instead of `float`, SageMath uses `RealLiteral` and `Rational` (where appropraite)"
    ]
   },
   {
@@ -156,13 +181,15 @@
    },
    "outputs": [],
    "source": [
-    "# In Sage the default is to use Sage Integers and Real numbers (other types are the same)\n",
-    "x=2\n",
-    "print(x,type(x)); \n",
-    "y=2.0; print(y,type(y))  #Combine multiple statements with ';' -- avoid this in practice since it reduces readability \n",
-    "r = 3 / 4; print(r,type(r))\n",
-    "z= 1+1j; print(z,type(z)) # Numerical complex numbers \n",
-    "z= 1+1*I; print(z,type(z)) # Symbolic complex numbers\n"
+    "x = 2 # Integer\n",
+    "y = 2.0 # Real/floating point numbers with `RealLiteral`\n",
+    "r = 3/4 # Rational\n",
+    "z_num = 1 + 1j # Numerical complex numbers with `ComplexNumber`\n",
+    "z_sym = 1 + 1*I # Symbolic complex numbers with `Expression`\n",
+    "\n",
+    "# Reduce writing and improve readability by iterating over a list using a `for` loop\n",
+    "for var in [x, y, r, z_num, z_sym]:\n",
+    "    print(var, type(var))"
    ]
   },
   {
@@ -170,7 +197,7 @@
    "metadata": {},
    "source": [
     "# Sets\n",
-    "Sets are useful to make lists with unique elements:"
+    "Sets are useful for making lists with unique elements, are order ambivalent, and can be defined using either braces `{}` or the `set()` constructor function."
    ]
   },
   {
@@ -179,32 +206,40 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "list(set([1,2,3,4,4,4,5]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "there are also intersections etc."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "set([1,2,3,4]).intersection(['a','b','c',1,2,8])"
+    "X = set([1,2,3,4,4,4,5])\n",
+    "Y = {5,3,1,4,2}\n",
+    "print(X)\n",
+    "print(Y)\n",
+    "print(list(X))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Different precision variables in Sage"
+    "The `set` type features many useful methods such as unions and intersections. See the documentation [here](https://docs.python.org/3/library/stdtypes.html#set)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = set([1, 2, 3, 4])\n",
+    "B = set(['a', 'b', 'c', 1, 2, 8])\n",
+    "A.intersection(B)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Precision of variables in SageMath\n",
+    "SageMath stores variables to higher levels of precision than Python\n",
+    "- The `RR` keyword denotes the Real Field with 53 bits of precision (double precision)\n",
+    "- The `CC` keyword denotes the Complex Field with 53 bits of precision\n",
+    "- We can construct fields with higher precision using `RealField(prec)` and `ComplexField(prec)`"
    ]
   },
   {
@@ -215,91 +250,15 @@
    },
    "outputs": [],
    "source": [
-    "# Real numbers (53 bits - double precision):\n",
-    "RR"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Higher precision\n",
-    "RealField(106)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "CC"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ComplexField(106)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "z=ComplexField(106)(1,10); z"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# There are also builtin constants that can be given to arbitrary precision\n",
-    "RR.pi()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "RealField(106).pi()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# And functions\n",
-    "exp(RealField(1000)(1))  # e^1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Alternatively as a method:\n",
-    "RealField(1000)(1)).exp()"
+    "for field in [RR, RealField(106), CC, ComplexField(106)]:\n",
+    "    print(field)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Objects, Parents, Elements and categories"
+    "We can contruct high precision complex numbers as field elements as follows:"
    ]
   },
   {
@@ -308,7 +267,42 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "In Python and even more so in SageMath everything is an object and has properties and methods. \n",
+    "my_complex_field = ComplexField(106)\n",
+    "z1 = my_complex_field(1,10)\n",
+    "z2 = my_complex_field(5,5)\n",
+    "\n",
+    "for num in [z1, z2, z1+z2]:\n",
+    "    print(num)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are also builtin constants that can be given to arbitrary precision"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(RR.pi())\n",
+    "print(RealField(106).pi())\n",
+    "high_prec_one = RealField(1000)(1)\n",
+    "print(high_prec_one)\n",
+    "print(exp(high_prec_one)) # Demonstrate the builtin `exp` function\n",
+    "print(high_prec_one.exp()) # Calculate exponential as a method of the `RealNumber` class"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Objects, Parents, Elements and categories\n",
+    "\n",
+    "In Python and even more so in SageMath everything is an object and has properties and methods. <br>\n",
     "In SageMath most (every?) object is either an Element or a Parent"
    ]
   },
@@ -318,8 +312,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "F = RealField(53) # parent\n",
-    "x = F(2) # element"
+    "F = RealField(53) # Parent\n",
+    "x = F(2) # Element\n",
+    "print(type(F))\n",
+    "print(type(x))\n",
+    "F.is_parent_of(x) # True\n",
+    "print(x in F) # True"
    ]
   },
   {
@@ -328,7 +326,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "F.is_parent_of(x)"
+    "x.parent() # Returns a copy of F"
    ]
   },
   {
@@ -337,7 +335,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x.parent()"
+    "x.category() # The category of x, a category of elements"
    ]
   },
   {
@@ -346,7 +344,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x in F"
+    "F.category() # The category of F"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### String formatting\n",
+    "In previous versions of Python there were more types of strings but in current Python there are basically only strings `str` and bytestrings `bytes` (which we do not discuss here)\n",
+    "\n",
+    "We can control how strings are formatted when printing by using either the `format` method or by using formatted strings, which are strings with an `f` character before the first quotation mark. Please see the examples below, and follow this [link](https://www.programiz.com/python-programming/methods/string/format) for a reference on string formatting. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = RR(2) # The real number 2, up to 53 bits of precision\n",
+    "print(\"x = {0}\".format(x))   # format method\n",
+    "print(f\"x = {x}\")            # f-strings\n",
+    "print(f\"x = {x.exp()}\")      # Can call functions in f-strings\n",
+    "print(f\"x = {float(RR.pi()):0.5f}\") # As floating point number with 5 decimals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Exercise 1**.  Print $e^{\\pi}$ as a floating point number to 225 decimal places."
    ]
   },
   {
@@ -368,20 +396,9 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### String formatting\n",
-    "In previous versions of Python there were more types of strings but in current Python there are basically onloy strings `str` and bytestrings `bytes` (which we forget about here)\n",
-    "\n",
-    "For printing string it is also useful to learn about formatted strings:"
    ]
   },
   {
@@ -390,32 +407,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"x={0}\".format(x))   # Python 2 formatting \n",
-    "print(f\"x={x}\")            # f-strings in Python 3\n",
-    "print(f\"x={x.exp()}\")      # Can call functions in strings\n",
-    "print(f\"x={float(RR.pi()):0.5f}\")       # As floating point number with 5 decimals\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Exercise 1**.  Print $e^{\\pi}$ as a floating point number to 225 decimal places."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -461,7 +459,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# does this make sense?\n",
+    "# Does this make sense?\n",
     "is_zero_mod_3(5.4)"
    ]
   },
@@ -475,12 +473,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "Sage has an alternative modulo: "
+    "Sage has an alternative modulo reduction function "
    ]
   },
   {
@@ -509,7 +505,7 @@
    "source": [
     "# Add handling of input\n",
     "def is_zero_mod_3(x):\n",
-    "    if not isinstance(x,int):\n",
+    "    if not isinstance(x, int):\n",
     "        raise ValueError(f\"Received input of type {type(x)}. This function needs an integer!\")\n",
     "    return x % 3 == 0"
    ]
@@ -558,7 +554,7 @@
    "source": [
     "# Add handling of input\n",
     "def is_zero_mod_3(x):\n",
-    "    if not isinstance(x,(int,Integer)):  # Multiple types should be given as a tuple\n",
+    "    if not isinstance(x, (int, Integer)):  # Multiple types should be given as a tuple\n",
     "        raise ValueError(f\"Received input of type {type(x)}. This function needs an integer!\")\n",
     "    return x % 3 == 0"
    ]
@@ -576,7 +572,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Can we help users to know in advance what input to expect?"
+    "When writing our own functions we can help future users check the expected inputs in advance by writing a docstring (documentation string)."
    ]
   },
   {
@@ -597,16 +593,15 @@
     "# Let's add a docstring\n",
     "def is_zero_mod_3(x):\n",
     "    r\"\"\"\n",
-    "    Return True if input is congruenct to 0 mod 3, otherwise return False\n",
+    "    Return True if input is congruent to 0 mod 3, otherwise return False\n",
     "    \n",
     "    INPUT:\n",
     "    \n",
     "    - ``x`` -- integer\n",
     "    \n",
-    "    OUTPUT: A boolean describing whether the input is congruent to 0 or not.\n",
-    "    \n",
+    "    OUTPUT: A boolean describing whether the input is congruent to 0 mod 3 or not.\n",
     "    \"\"\"\n",
-    "    if not isinstance(x,(Integer,int)):\n",
+    "    if not isinstance(x, (Integer, int)):\n",
     "        raise ValueError(f\"Received input of type {type(x)}. This function needs an integer!\")\n",
     "    return x % 3 == 0"
    ]
@@ -646,12 +641,13 @@
    "outputs": [],
    "source": [
     "# Scalar values gets passed by value into functions, i.e. what happens in the function stays in the function:\n",
-    "x=1\n",
-    "def add_one(x):\n",
-    "    x=x+1\n",
-    "    print(f\"x={x}\")\n",
+    "x = 1\n",
     "\n",
-    "y=1\n",
+    "def add_one(x):\n",
+    "    x = x + 1\n",
+    "    print(f\"x = {x}\")\n",
+    "\n",
+    "y = 1\n",
     "print(y)\n",
     "add_one(y)\n",
     "print(y)\n",
@@ -664,14 +660,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Dicts gets passed by reference, i.e. what happens in the function also happens outside.\n",
-    "d={'a':1}\n",
-    "print(d['a'])     # Get d['a'] and raise an error if 'a' is not a key\n",
+    "# Dictionaries get passed by reference, i.e. what happens in the function also happens outside.\n",
+    "d = {'a': 1}\n",
+    "print(d['a']) # Get d['a'] and raise an error if 'a' is not a key\n",
     "print(d.get('b','default')) # Get d['b'] if 'b' is a key, otherwise return 'default' (or None if no default value is given)\n",
     "\n",
     "def add_one(d):\n",
-    "    d['a']=d.get('a')+1\n",
-    "    print(f\"d={d}\")\n",
+    "    d['a'] = d.get('a') + 1\n",
+    "    print(f\"d = {d}\")\n",
     "\n",
     "print(d)\n",
     "add_one(d)\n",
@@ -684,7 +680,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "[1]+1"
+    "[1] + 1 # Addition of integers and lists in this way is not supported"
    ]
   },
   {
@@ -692,7 +688,7 @@
    "metadata": {},
    "source": [
     " ### Type hints\n",
-    " In Python3 it is also possible to add type hints.\n",
+    " In Python 3 it is also possible to add type hints. <br>\n",
     " Note that these are mainly to guide an IDE or to be checked by a pre-parser. They are not enforced by Python. "
    ]
   },
@@ -705,16 +701,15 @@
     "# Let's add a docstring\n",
     "def is_zero_mod_3(x: int) -> bool:\n",
     "    r\"\"\"\n",
-    "    Return True if input is congruenct to 0 mod 3, otherwise return False\n",
+    "    Return True if input is congruent to 0 mod 3, otherwise return False\n",
     "    \n",
     "    INPUT:\n",
     "    \n",
     "    - ``x`` -- integer\n",
     "    \n",
-    "    OUTPUT: A boolean describing whether the input is congruent to 0 or not.\n",
-    "    \n",
+    "    OUTPUT: A boolean describing whether the input is congruent to 0 mod 3 or not.\n",
     "    \"\"\"\n",
-    "    if not isinstance(x,(Integer,int)):\n",
+    "    if not isinstance(x, (Integer, int)):\n",
     "        raise ValueError(f\"Received input of type {type(x)}. This function needs an integer!\")\n",
     "    return x % 3 == 0"
    ]

--- a/Lesson1-Introduction.ipynb
+++ b/Lesson1-Introduction.ipynb
@@ -759,9 +759,41 @@
    "source": [
     "**Exercise 2**  Write a function with the following specifications:\n",
     "  1. Takes as input an integer $x$ and a positive integer $n$\n",
-    "  2. Returns True if $x^2$ is a square modulo $n$ and otherwise False.\n",
+    "  2. Returns True if $x$ is congruent to a square modulo $n$ and otherwise False.\n",
     "  3. Handles errors in input with sensible error messages.\n",
     "  4. Includes a docstring which describes the function. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def is_square_residue(x, n: int) -> bool:\n",
+    "    r\"\"\"\n",
+    "    Return `True` if $x$ is congruent to a squared integer modulo $n$, otherwise return `False`\n",
+    "    \n",
+    "    INPUTS:\n",
+    "    - ``x`` -- an integer\n",
+    "    - ``n`` -- a positive integer\n",
+    "    \n",
+    "    OUTPUT: A boolean describing whether there are any solutions $a$ to $x \\equiv a^{2} \\mod n$ for inputs `x` and `n`\n",
+    "    \"\"\"\n",
+    "    if not (isinstance(x, (Integer, int)) and isinstance(n, (Integer, int)) and n > 0):\n",
+    "        raise ValueError(f\"Received inputs (x, n) = ({x}, {n}) of type ({type(x)}, {type(n)}). Inputs should be integers, with n positive!\")\n",
+    "    return (x % n) in set(a**2 for a in range(n))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 8\n",
+    "for x in range(n):\n",
+    "    print(x, is_square_residue(x, n))"
    ]
   },
   {
@@ -800,13 +832,6 @@
    "source": [
     "\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Lesson1-Introduction.ipynb
+++ b/Lesson1-Introduction.ipynb
@@ -378,12 +378,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "x.category()"
+    "**Python solution**: Use the `decimal` library ([documentation](https://docs.python.org/3.8/library/decimal.html))"
    ]
   },
   {
@@ -392,13 +390,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "F.category()"
+    "%%python3\n",
+    "import decimal, math\n",
+    "import numpy as np\n",
+    "decimal.getcontext().prec = 225\n",
+    "print(f\"{decimal.Decimal(math.pi)}\\n{decimal.Decimal(np.pi)}\") "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The cell above shows that there is not enough precision in the stored values of `pi` in the `math` and `numpy` libraries for our application, so we must use an algorithm to calculate it to a higher precision. We use the [Gauss-Legendre algorithm](https://en.wikipedia.org/wiki/Gauss-Legendre_algorithm) for its fast convergence rate."
    ]
   },
   {
@@ -407,12 +410,43 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%python3\n",
+    "from decimal import Decimal, getcontext\n",
+    "import numpy as np\n",
+    "getcontext().prec = 227\n",
+    "num_iter = 8\n",
+    "one = Decimal(1)\n",
+    "two = Decimal(2)\n",
+    "four = Decimal(4)\n",
+    "\n",
+    "def gauss_legendre_algorithm(num_iter):\n",
+    "    r\"\"\"Implement the Gauss-Legendre algorithm for the specified number of iterations\n",
+    "    \n",
+    "    Return an `np.array` of approximations to pi of increasing accuracy\"\"\"\n",
+    "    a, b, t, = [one], [two.sqrt()/two], [one/four]\n",
+    "    approx = list()\n",
+    "    for i in range(num_iter):\n",
+    "        a.append((a[i] + b[i]) / two)\n",
+    "        b.append((a[i] * b[i]).sqrt())\n",
+    "        t.append(t[i] - getcontext().power(two, Decimal(i)) * (a[i] - a[i+1]) * (a[i] - a[i+1]))\n",
+    "        approx.append((a[i+1] + b[i+1]) * (a[i+1] + b[i+1]) / (four * t[i+1]))\n",
+    "    return np.array(approx)\n",
+    "\n",
+    "approx = gauss_legendre_algorithm(num_iter)\n",
+    "print(approx == approx[-1]) # Shows that we have stabilised to 225dp precision after 7 iterations\n",
+    "precise_pi = approx[-1]\n",
+    "result = precise_pi.exp()\n",
+    "print(result)\n",
+    "print(f\"Number of decimal places = {len(str(result).split('.')[-1])}\") # Counts digits after decimal point"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "**SageMath solution**: \n",
+    "- Note that this can be calculated using many fewer lines of code since there are builtin SageMath algorithms running behind the scenes. \n",
+    "- Note also that we must convert from bit (binary) precision to precision in decimal places by multiplying by $\\log_{2}(10) \\approx 3.32$"
    ]
   },
   {
@@ -420,7 +454,12 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "required_bit_prec = 228 * RR(10).log2() # Calculate required binary precision from decimal\n",
+    "exp_pi = RealField(required_bit_prec).pi().exp()\n",
+    "print(exp_pi)\n",
+    "print(f\"Number of decimal places = {len(str(exp_pi).split('.')[-1])}\") # Counts digits after decimal point"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
# Summary of Changes
Please see also commit messages and individual commit differences
1. Some typo fixes; 
2. Markdown editing to improve presentability (e.g. of itemized lists in lines 15-68, line breaks ); 
3. Including more links to online documentation and reference material (e.g. lines 30, 74, 200, 357); 
4. More help for beginners new to Jupyter notebooks (lines 76-78, 106-109, 130-131);
5. Space out code to match PEP8 guidelines and improve readability (e.g. lines 133-144, 184-188, 366-370);
6. Expanding existing comments (e.g. lines 171-173, 184-188, 238-242, 274-275, 354-357);
7. Subtle introduction to `for` loops, which should be familiar from earlier carpentry lessons in Unix shell (lines 190-192, 253-254);
8. Expanding examples and commentary on `set` data type (lines 200, 209-213, 220, 229-231);
9. Comparison of solutions to exercise 1 in pure Python vs. SageMath (lines 377-462);
10. Fix statement of exercise 2 and provide a solution (lines 762-798)

## Top 3 most likely (pedagogically) controversial changes for review: 9, 7, 10
Commentary on the proposed changes
9. Displays the advantage of SageMath over Python for easy high-precision calculations of simple mathematical functions, but complex Python implementation may put off beginners. Could advise readers to skip the details, but just compare relative implementation lengths (lines of code).
7. Introduces `for` loops without elaborate explanation earlier in the lessons (as also discussed in lesson 2), but I think this won't be a problem for students because `for` loops were also just covered in the Unix shell Software Carpentry.
10. Solution could be moved to ExampleSolutions.ipynb if deemed appropriate, so that students can try the exercise for themselves first.